### PR TITLE
Explicit modality set when "New..." is selected

### DIFF
--- a/Chapter03/calendar_app.py
+++ b/Chapter03/calendar_app.py
@@ -33,6 +33,7 @@ class CategoryWindow(qtw.QWidget):
             clicked=self.close
             )
         self.layout().addWidget(self.cancel_btn)
+        self.setWindowModality(qtc.Qt.ApplicationModal)
         self.show()
 
     @qtc.pyqtSlot()


### PR DESCRIPTION
The popup that happens for entering a category when "New..." is selected is currently NOT modal, despite line 14 stating "modal=True"

I tested it on Ubuntu, Windows 10 and macOS (Big Sur).  All of them showed the category dialog and you could put it in the background and return to the main calendar window, which wouldn't be the correct behavior.

Adding this line before the show command:
self.setWindowModality(qtc.Qt.ApplicationModal)
Makes it so the Category dialog is modal.

Tested on Windows, Ubuntu, and macOS.

I'm just learning PyQt, so perhaps there's a better way, but this way does work.